### PR TITLE
Update pi_fm_rds.c

### DIFF
--- a/src/pi_fm_rds.c
+++ b/src/pi_fm_rds.c
@@ -419,7 +419,10 @@ int tx(uint32_t carrier_freq, char *audio_file, uint16_t pi, char *ps, char *rt,
     int data_index = 0;
 
     // Initialize the baseband generator
-    if(fm_mpx_open(audio_file, DATA_SIZE) < 0) return -1;
+	if (fm_mpx_open(audio_file, DATA_SIZE) < 0) {
+		terminate(0);
+		return -1;
+	}
     
     // Initialize the RDS modulator
     char myps[9] = {0};


### PR DESCRIPTION
In case fm_mpx_open() returns -1 (as when it is unable to read from stdin), tx also returns -1 without terminating, causing the Pi to crash & burn with unforeseeable consequences.
