### PR TITLE
carrier wave kill

### DIFF
--- a/src/pi_fm_rds.c
+++ b/src/pi_fm_rds.c
@@ -512,6 +512,64 @@ int tx(uint32_t carrier_freq, char *audio_file, uint16_t pi, char *ps, char *rt,
     return 0;
 }
 
+#define BCM2708_PERI_BASE        0x20000000
+//#define GPIO_BASE                (BCM2708_PERI_BASE + 0x200000) /* GPIO controller */
+#define INP_GPIO(g) *(gpio+((g)/10)) &= ~(7<<(((g)%10)*3))
+#define OUT_GPIO(g) *(gpio+((g)/10)) |=  (1<<(((g)%10)*3))
+#define GPIO_SET *(gpio+7)  // sets   bits which are 1 ignores bits which are 0
+
+//#define PAGE_SIZE (4*1024)
+#define BLOCK_SIZE (4*1024)
+
+int  mem_fd;
+void *gpio_map;
+// I/O access
+volatile unsigned *gpio;
+
+void setup_io()
+{
+   /* open /dev/mem */
+   if ((mem_fd = open("/dev/mem", O_RDWR|O_SYNC) ) < 0) {
+      printf("can't open /dev/mem \n");
+      exit(-1);
+   }
+
+   /* mmap GPIO */
+   gpio_map = mmap(
+      NULL,             //Any adddress in our space will do
+      BLOCK_SIZE,       //Map length
+      PROT_READ|PROT_WRITE,// Enable reading & writting to mapped memory
+      MAP_SHARED,       //Shared with other processes
+      mem_fd,           //File to map
+      GPIO_BASE         //Offset to GPIO peripheral
+   );
+
+   close(mem_fd); //No need to keep mem_fd open after mmap
+
+   if (gpio_map == MAP_FAILED) {
+      printf("mmap error %d\n", (int)gpio_map);//errno also set!
+      exit(-1);
+   }
+
+   // Always use volatile pointer!
+   gpio = (volatile unsigned *)gpio_map;
+
+
+} // setup_io
+
+void kill_fm(){
+    setup_io();
+    INP_GPIO(4); // must use INP_GPIO before we can use OUT_GPIO
+    OUT_GPIO(4);
+    GPIO_SET = 1<<4;
+    printf("FM Transmission terminated.\n");
+}
+
+void print_info(){
+	printf("Syntax: pi_fm_rds [-freq freq] [-audio file] [-ppm ppm_error] [-pi pi_code]\n"
+           "                  [-ps ps_text] [-rt rt_text] [-ctl control_pipe] [-autokill]\n"
+           "                  [-kill]\n");
+}
 
 int main(int argc, char **argv) {
     char *audio_file = NULL;
@@ -524,6 +582,10 @@ int main(int argc, char **argv) {
     
     
     // Parse command-line arguments
+    if(argc <= 1){
+    	print_info();
+        exit(0);
+    }
     for(int i=1; i<argc; i++) {
         char *arg = argv[i];
         char *param = NULL;
@@ -553,10 +615,14 @@ int main(int argc, char **argv) {
         } else if(strcmp("-ctl", arg)==0 && param != NULL) {
             i++;
             control_pipe = param;
+        } else if(strcmp("-autokill", arg)==0) { //automatically kill carrierwave at exit
+            atexit(kill_fm);
+        } else if(strcmp("-kill", arg)==0) { //kill carrierwave now and exit
+            kill_fm();
+            terminate(0);
         } else {
-            fatal("Unrecognised argument: %s\n"
-            "Syntax: pi_fm_rds [-freq freq] [-audio file] [-ppm ppm_error] [-pi pi_code]\n"
-            "                  [-ps ps_text] [-rt rt_text] [-ctl control_pipe]\n", arg);
+            print_info();
+            exit(0);
         }
     }
     

--- a/src/pi_fm_rds.c
+++ b/src/pi_fm_rds.c
@@ -621,6 +621,7 @@ int main(int argc, char **argv) {
             kill_fm();
             terminate(0);
         } else {
+            printf("Unrecognised argument: %s\n", arg);
             print_info();
             exit(0);
         }


### PR DESCRIPTION
This patch adds arguments to kill the carrier wave on exit, or kill a carrier wave that's still active and clean up the dma after an unclean exit.

It also moves the argument info printing to a separate function, and when the program is run without arguments just shows the argument info and exits.