### PR TITLE
Preemphasis Implementation

### DIFF
--- a/src/fm_mpx.c
+++ b/src/fm_mpx.c
@@ -84,7 +84,7 @@ float *alloc_empty_buffer(size_t length) {
 }
 
 
-int fm_mpx_open(char *filename, size_t len, float preemphasis_corner_freq) {
+int fm_mpx_open(char *filename, size_t len, float cutoff_freq, float preemphasis_corner_freq) {
     length = len;
 
     if(filename != NULL) {
@@ -130,9 +130,7 @@ int fm_mpx_open(char *filename, size_t len, float preemphasis_corner_freq) {
         
     
         // Create the low-pass FIR filter
-        float cutoff_freq = 22050;
         if(in_samplerate/2 < cutoff_freq) cutoff_freq = in_samplerate/2;
-    
     
     
         low_pass_fir[FIR_HALF_SIZE-1] = 2 * cutoff_freq / 228000 /2;

--- a/src/fm_mpx.c
+++ b/src/fm_mpx.c
@@ -66,6 +66,12 @@ float fir_buffer_stereo[FIR_SIZE] = {0};
 int fir_index = 0;
 int channels;
 
+float *last_buffer_val;
+float preemphasis_corner_freq;
+float preemphasis_prewarp;
+float preemphasis_coefficient_a;
+float preemphasis_coefficient_b;
+
 SNDFILE *inf;
 
 
@@ -114,8 +120,18 @@ int fm_mpx_open(char *filename, size_t len) {
             printf("%d channels, generating stereo multiplex.\n", channels);
         } else {
             printf("1 channel, monophonic operation.\n");
-        }
-    
+        } 
+		
+		// Create the preemphasis
+		last_buffer_val = (float*) malloc(sizeof(float)*channels);
+		for(int i=0;i<channels;i++) last_buffer_val[i] = 0;
+		
+		preemphasis_corner_freq = 2120; //3.185kHz for Europe, 2,120kHz for US
+		preemphasis_prewarp = tan(PI*preemphasis_corner_freq/in_samplerate);
+		preemphasis_coefficient_a = (1.0 - preemphasis_prewarp)/(1.0 + preemphasis_prewarp);
+		preemphasis_coefficient_b = (1.0 + preemphasis_coefficient_a)/2.0;
+		printf("Created preemphasis with \n%lf \n%lf \n%lf \n%lf", preemphasis_corner_freq, preemphasis_prewarp, preemphasis_coefficient_a, preemphasis_coefficient_b);
+		
     
         // Create the low-pass FIR filter
         float cutoff_freq = 15000 * .8;
@@ -181,6 +197,21 @@ int fm_mpx_get_samples(float *mpx_buffer) {
                             return -1;
                         }
                     } else {
+						//apply preemphasis
+						int k;
+						int l;
+						float tmp;
+						for(k=0;k<audio_len;k+=channels) {
+							for(l=0;l<channels;l++) {
+								tmp = audio_buffer[k+l];
+								audio_buffer[k+l] =	preemphasis_coefficient_b*audio_buffer[k+l] -
+													preemphasis_coefficient_b*last_buffer_val[l] +
+													preemphasis_coefficient_a*last_buffer_val[l];
+								last_buffer_val[l] = tmp;
+								
+							}
+						}
+						
                         break;
                     }
                 }

--- a/src/fm_mpx.c
+++ b/src/fm_mpx.c
@@ -121,17 +121,17 @@ int fm_mpx_open(char *filename, size_t len) {
         } else {
             printf("1 channel, monophonic operation.\n");
         } 
-		
-		// Create the preemphasis
-		last_buffer_val = (float*) malloc(sizeof(float)*channels);
-		for(int i=0;i<channels;i++) last_buffer_val[i] = 0;
-		
-		preemphasis_corner_freq = 2120; //3.185kHz for Europe, 2,120kHz for US
-		preemphasis_prewarp = tan(PI*preemphasis_corner_freq/in_samplerate);
-		preemphasis_coefficient_a = (1.0 - preemphasis_prewarp)/(1.0 + preemphasis_prewarp);
-		preemphasis_coefficient_b = (1.0 + preemphasis_coefficient_a)/2.0;
-		printf("Created preemphasis with \n%lf \n%lf \n%lf \n%lf", preemphasis_corner_freq, preemphasis_prewarp, preemphasis_coefficient_a, preemphasis_coefficient_b);
-		
+        
+        // Create the preemphasis
+        last_buffer_val = (float*) malloc(sizeof(float)*channels);
+        for(int i=0;i<channels;i++) last_buffer_val[i] = 0;
+        
+        preemphasis_corner_freq = 2120; //3.185kHz for Europe, 2,120kHz for US
+        preemphasis_prewarp = tan(PI*preemphasis_corner_freq/in_samplerate);
+        preemphasis_coefficient_a = (1.0 - preemphasis_prewarp)/(1.0 + preemphasis_prewarp);
+        preemphasis_coefficient_b = (1.0 + preemphasis_coefficient_a)/2.0;
+        printf("Created preemphasis with \n%lf \n%lf \n%lf \n%lf", preemphasis_corner_freq, preemphasis_prewarp, preemphasis_coefficient_a, preemphasis_coefficient_b);
+        
     
         // Create the low-pass FIR filter
         float cutoff_freq = 15000 * .8;
@@ -197,21 +197,21 @@ int fm_mpx_get_samples(float *mpx_buffer) {
                             return -1;
                         }
                     } else {
-						//apply preemphasis
-						int k;
-						int l;
-						float tmp;
-						for(k=0;k<audio_len;k+=channels) {
-							for(l=0;l<channels;l++) {
-								tmp = audio_buffer[k+l];
-								audio_buffer[k+l] =	preemphasis_coefficient_b*audio_buffer[k+l] -
-													preemphasis_coefficient_b*last_buffer_val[l] +
-													preemphasis_coefficient_a*last_buffer_val[l];
-								last_buffer_val[l] = tmp;
-								
-							}
-						}
-						
+                        //apply preemphasis
+                        int k;
+                        int l;
+                        float tmp;
+                        for(k=0;k<audio_len;k+=channels) {
+                            for(l=0;l<channels;l++) {
+                                tmp = audio_buffer[k+l];
+                                audio_buffer[k+l] = preemphasis_coefficient_b*audio_buffer[k+l] -
+                                                    preemphasis_coefficient_b*last_buffer_val[l] +
+                                                    preemphasis_coefficient_a*last_buffer_val[l];
+                                last_buffer_val[l] = tmp;
+                                
+                            }
+                        }
+                        
                         break;
                     }
                 }

--- a/src/fm_mpx.c
+++ b/src/fm_mpx.c
@@ -66,11 +66,13 @@ float fir_buffer_stereo[FIR_SIZE] = {0};
 int fir_index = 0;
 int channels;
 
+//3.185kHz for Europe, 2.120kHz for US
+const float PREEMPHASIS_US = 2120;
+const float PREEMPHASIS_EU = 3185;
 float *last_buffer_val;
 float preemphasis_corner_freq;
 float preemphasis_prewarp;
-float preemphasis_coefficient_a;
-float preemphasis_coefficient_b;
+float preemphasis_coefficient;
 
 SNDFILE *inf;
 
@@ -126,11 +128,10 @@ int fm_mpx_open(char *filename, size_t len) {
         last_buffer_val = (float*) malloc(sizeof(float)*channels);
         for(int i=0;i<channels;i++) last_buffer_val[i] = 0;
         
-        preemphasis_corner_freq = 2120; //3.185kHz for Europe, 2,120kHz for US
+        preemphasis_corner_freq = PREEMPHASIS_EU;
         preemphasis_prewarp = tan(PI*preemphasis_corner_freq/in_samplerate);
-        preemphasis_coefficient_a = (1.0 - preemphasis_prewarp)/(1.0 + preemphasis_prewarp);
-        preemphasis_coefficient_b = (1.0 + preemphasis_coefficient_a)/2.0;
-        printf("Created preemphasis with \n%lf \n%lf \n%lf \n%lf", preemphasis_corner_freq, preemphasis_prewarp, preemphasis_coefficient_a, preemphasis_coefficient_b);
+        preemphasis_coefficient = (1.0 + (1.0 - preemphasis_prewarp)/(1.0 + preemphasis_prewarp))/2.0;
+        printf("Created preemphasis with with cutoff at %.1f Hz\n", preemphasis_corner_freq);
         
     
         // Create the low-pass FIR filter
@@ -204,11 +205,8 @@ int fm_mpx_get_samples(float *mpx_buffer) {
                         for(k=0;k<audio_len;k+=channels) {
                             for(l=0;l<channels;l++) {
                                 tmp = audio_buffer[k+l];
-                                audio_buffer[k+l] = preemphasis_coefficient_b*audio_buffer[k+l] -
-                                                    preemphasis_coefficient_b*last_buffer_val[l] +
-                                                    preemphasis_coefficient_a*last_buffer_val[l];
+                                audio_buffer[k+l] = audio_buffer[k+l] - preemphasis_coefficient*last_buffer_val[l];
                                 last_buffer_val[l] = tmp;
-                                
                             }
                         }
                         

--- a/src/fm_mpx.c
+++ b/src/fm_mpx.c
@@ -66,11 +66,7 @@ float fir_buffer_stereo[FIR_SIZE] = {0};
 int fir_index = 0;
 int channels;
 
-//3.185kHz for Europe, 2.120kHz for US
-const float PREEMPHASIS_US = 2120;
-const float PREEMPHASIS_EU = 3185;
 float *last_buffer_val;
-float preemphasis_corner_freq;
 float preemphasis_prewarp;
 float preemphasis_coefficient;
 
@@ -88,7 +84,7 @@ float *alloc_empty_buffer(size_t length) {
 }
 
 
-int fm_mpx_open(char *filename, size_t len) {
+int fm_mpx_open(char *filename, size_t len, float preemphasis_corner_freq) {
     length = len;
 
     if(filename != NULL) {
@@ -128,10 +124,9 @@ int fm_mpx_open(char *filename, size_t len) {
         last_buffer_val = (float*) malloc(sizeof(float)*channels);
         for(int i=0;i<channels;i++) last_buffer_val[i] = 0;
         
-        preemphasis_corner_freq = PREEMPHASIS_EU;
         preemphasis_prewarp = tan(PI*preemphasis_corner_freq/in_samplerate);
         preemphasis_coefficient = (1.0 + (1.0 - preemphasis_prewarp)/(1.0 + preemphasis_prewarp))/2.0;
-        printf("Created preemphasis with with cutoff at %.1f Hz\n", preemphasis_corner_freq);
+        printf("Created preemphasis with cutoff at %.1f Hz\n", preemphasis_corner_freq);
         
     
         // Create the low-pass FIR filter

--- a/src/fm_mpx.c
+++ b/src/fm_mpx.c
@@ -134,8 +134,8 @@ int fm_mpx_open(char *filename, size_t len) {
         
     
         // Create the low-pass FIR filter
-        float cutoff_freq = 15000 * .8;
-        if(in_samplerate/2 < cutoff_freq) cutoff_freq = in_samplerate/2 * .8;
+        float cutoff_freq = 22050;
+        if(in_samplerate/2 < cutoff_freq) cutoff_freq = in_samplerate/2;
     
     
     

--- a/src/fm_mpx.h
+++ b/src/fm_mpx.h
@@ -21,6 +21,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-extern int fm_mpx_open(char *filename, size_t len, float preemphasis_corner_freq);
+extern int fm_mpx_open(char *filename, size_t len, float cutoff_freq, float preemphasis_corner_freq);
 extern int fm_mpx_get_samples(float *mpx_buffer);
 extern int fm_mpx_close();

--- a/src/fm_mpx.h
+++ b/src/fm_mpx.h
@@ -21,6 +21,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-extern int fm_mpx_open(char *filename, size_t len);
+extern int fm_mpx_open(char *filename, size_t len, float preemphasis_corner_freq);
 extern int fm_mpx_get_samples(float *mpx_buffer);
 extern int fm_mpx_close();


### PR DESCRIPTION
So... this is my preemphasis implementation, along with some minor improvements.
Even though i have no knowledge about audio filtering, and i am therefore not quite sure if i picked my coefficient right, the sound quality improved quite a bit.

seriously, i cant hear the difference between playing the original file and listening to the PiFm generated FM.

Because in US the preemphasis' cutoff frequency differs to the one used in EU, i added the functionality to change it via CLI with -preemph [eu/us] (default is us)

Also, i added a feature that let's you change the lowpass cutoff frequency by adding -cutoff [compliant/quality] to your parameters (default is compliant). It further improves the quality, and since you should not broadcast fm with this setup anyways, why not just allow higher frequencies since it doesnt matter when using with a grounded coax cable anyways.