### PR TITLE
Fix compilation for aarch64

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -12,6 +12,9 @@ ifeq ($(UNAME), armv6l)
 else ifeq ($(UNAME), armv7l)
 	CFLAGS = $(STD_CFLAGS) -march=armv7-a -mtune=arm1176jzf-s -mfloat-abi=hard -mfpu=vfp -ffast-math -DRASPI=2
 	TARGET = pi2
+else ifeq ($(UNAME), aarch64)
+	CFLAGS = $(STD_CFLAGS) -march=armv8-a -O2 -pipe -fstack-protector-strong -fno-plt -ffast-math -DRASPI=2
+	TARGET = pi2
 else
 	CFLAGS = $(STD_CFLAGS)
 	TARGET = other

--- a/src/mailbox.c
+++ b/src/mailbox.c
@@ -35,6 +35,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sys/mman.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 
 #include "mailbox.h"
 


### PR DESCRIPTION
It compiles and runs fine with these changes on the Raspberry Pi 3 B+ under the aarch64 version Arch Linux ARM.

Note that hardcoding flags that way is not nice. Maybe it is worth setting up a more sophisticated build system for this project. But for the time being this suffices.

Not sure why sysmacros.h isn't required in your case.