### PR TITLE
Fix compile error on Buster

### DIFF
--- a/src/mailbox.c
+++ b/src/mailbox.c
@@ -36,6 +36,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 
+// Fixes compile error "mailbox.c:260: undefined reference to `makedev'"
+#include <sys/sysmacros.h>
+
 #include "mailbox.h"
 
 #define PAGE_SIZE (4*1024)


### PR DESCRIPTION
Fixes `mailbox.c:260: undefined reference to 'makedev'` on Raspbian Buster and probably other OSes

Based on [this fix](https://github.com/joan2937/pigpio/commit/73ade1954b41ddacc2c3d235cd6722f19f0c401c) for [this similar issue](https://github.com/joan2937/pigpio/issues/188) encountered when building a different project.