### PR TITLE
Makefile: Fix static linking

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -31,13 +31,13 @@ CFLAGS = $(STD_CFLAGS) $(ARCH_CFLAGS) -DRASPI=$(TARGET)
 ifneq ($(TARGET), other)
 
 app: rds.o waveforms.o pi_fm_rds.o fm_mpx.o control_pipe.o mailbox.o
-	$(CC) -o pi_fm_rds rds.o waveforms.o mailbox.o pi_fm_rds.o fm_mpx.o control_pipe.o -lm -lsndfile
+	$(CC) -o pi_fm_rds rds.o waveforms.o mailbox.o pi_fm_rds.o fm_mpx.o control_pipe.o -lsndfile -lm
 
 endif
 
 
 rds_wav: rds.o waveforms.o rds_wav.o fm_mpx.o
-	$(CC) -o rds_wav rds_wav.o rds.o waveforms.o fm_mpx.o -lm -lsndfile
+	$(CC) -o rds_wav rds_wav.o rds.o waveforms.o fm_mpx.o -lsndfile -lm
 
 rds.o: rds.c waveforms.h
 	$(CC) $(CFLAGS) rds.c


### PR DESCRIPTION
Since libsndfile uses funtions from libm, the -lm should be specified
after libsndfile for static linking.

Signed-off-by: "Eric Limpens" <Limpens@gmail.com>
[Retrieved (and slightly updated) from:
https://git.buildroot.net/buildroot/tree/package/pifmrds/0003-Makefile-fix-static-link.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>