### PR TITLE
Add --no-loop option to stop audio at end of file

### DIFF
--- a/src/fm_mpx.c
+++ b/src/fm_mpx.c
@@ -159,7 +159,7 @@ int fm_mpx_open(char *filename, size_t len) {
 
 // samples provided by this function are in 0..10: they need to be divided by
 // 10 after.
-int fm_mpx_get_samples(float *mpx_buffer) {
+int fm_mpx_get_samples(float *mpx_buffer, uint8_t no_loop) {
     get_rds_samples(mpx_buffer, length);
 
     if(inf  == NULL) return 0; // if there is no audio, stop here
@@ -176,10 +176,15 @@ int fm_mpx_get_samples(float *mpx_buffer) {
                         return -1;
                     }
                     if(audio_len == 0) {
-                        if( sf_seek(inf, 0, SEEK_SET) < 0 ) {
-                            fprintf(stderr, "Could not rewind in audio file, terminating\n");
-                            return -1;
-                        }
+			if (no_loop) {
+				fprintf(stderr, "End of file reached, stopping.\n");
+				return -1;
+			} else {
+                        	if( sf_seek(inf, 0, SEEK_SET) < 0 ) {
+	                            fprintf(stderr, "Could not rewind in audio file, terminating\n");
+        	                    return -1;
+                        	}
+			}
                     } else {
                         break;
                     }

--- a/src/fm_mpx.h
+++ b/src/fm_mpx.h
@@ -22,5 +22,5 @@
 */
 
 extern int fm_mpx_open(char *filename, size_t len);
-extern int fm_mpx_get_samples(float *mpx_buffer);
+extern int fm_mpx_get_samples(float *mpx_buffer, uint8_t no_loop);
 extern int fm_mpx_close();


### PR DESCRIPTION
This patch avoids the unnecessary loop when reading audio, simplifying the fm_mpx_get_samples function.

It's more of a “dummy patch” for testing purposes — useful for trying things out once, not necessarily the final solution.